### PR TITLE
update to use aws sdk v2

### DIFF
--- a/manifests/generic.rb
+++ b/manifests/generic.rb
@@ -23,7 +23,7 @@ class GenericManifest
 
   def initialize
     if ENV['AWS_ACCESS_KEY_ID'] != nil
-      AWS.config({
+      Aws.config.update({
         access_key_id: ENV['AWS_ACCESS_KEY_ID'],
         secret_access_key: ENV['AWS_SECRET_KEY']
       })
@@ -97,9 +97,9 @@ class GenericManifest
       end
 
       begin
-        grouplist = zooniverse_data_bucket.objects["#{PROJECT_DATA_PATH}/#{project_name}/#{CSV_GROUPLIST_NAME}"]
-        csv_file_data = CSV.parse(grouplist.read)
-      rescue AWS::S3::Errors::NoSuchKey
+        grouplist = zooniverse_data_bucket.object("#{PROJECT_DATA_PATH}/#{project_name}/#{CSV_GROUPLIST_NAME}")
+        csv_file_data = CSV.parse(grouplist.get.body.read)
+      rescue Aws::S3::Errors::NoSuchKey
         return
       end
       @group_header_row = csv_file_data.shift
@@ -122,8 +122,8 @@ class GenericManifest
     end
 
     def load_image_metadata
-      filelist = zooniverse_data_bucket.objects["#{PROJECT_DATA_PATH}/#{project_name}/#{CSV_FILELIST_NAME}"]
-      csv_file_data = CSV.parse(filelist.read.unpack('U*').pack('U*'))
+      filelist = zooniverse_data_bucket.object("#{PROJECT_DATA_PATH}/#{project_name}/#{CSV_FILELIST_NAME}")
+      csv_file_data = CSV.parse(filelist.get.body.read.unpack('U*').pack('U*'))
       @image_header_row = csv_file_data.shift
       read_image_file_rows(csv_file_data)
     end
@@ -179,11 +179,11 @@ class GenericManifest
     end
 
     def s3
-      @s3 ||= AWS::S3.new
+      self.class.s3
     end
 
     def zooniverse_data_bucket
-      @zoo_data_bucket ||= s3.buckets['zooniverse-data']
+      @zoo_data_bucket ||= s3.bucket('zooniverse-data')
     end
 end
 

--- a/zooniverse_data.gemspec
+++ b/zooniverse_data.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bson', '1.9.2'
   spec.add_development_dependency 'bson_ext', '1.9.2'
   spec.add_runtime_dependency 'fastimage', '1.6.0'
-  spec.add_runtime_dependency 'aws-sdk', '~> 1.30.0'
+  spec.add_runtime_dependency 'aws-sdk', '~>2.3.18'
   spec.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
This PR bumps the aws-sdk version to latest (2.3.18) and updates the code to use the new gem api. I've tested with generic manifest and it worked. i haven't tested anything else. If people are happy with this we shoudl cut a new major version gem and iterate on fixing this one as problems arise.

This will fix issues with generating manifests for ouroboros data imports as S3 requires KMS v4 sigs since we turned on encryption. I'm happy to close this if we can get s3 signatures working with the sdk v1 but i couldn't see how to reading the docs. To me it looks like support only came in in v2 of the sdk.
